### PR TITLE
feat(domain): define core models and interfaces for global reporting

### DIFF
--- a/pharmagob/v1/models/messages/pubsub_msgs.py
+++ b/pharmagob/v1/models/messages/pubsub_msgs.py
@@ -10,6 +10,7 @@ from pharmagob.v1.models.minified import min_models
 from pharmagob.v1.models.shipment import ShipmentModel
 from pharmagob.v1.models.shipment_detail import ShipmentDetailModel
 from pharmagob.v1.models.stock_transfer import StockTransferModel
+from pharmagob.v1.models.reports import ReportRequestModel
 
 
 @dataclass
@@ -188,3 +189,12 @@ class PharmagobShipmentDetiailsPubsubMessage(BasePubsubMessage):
             "origin": self.origin,
             "review_status": self.review_status,
         }
+    
+@dataclass(kw_only=True)
+class GlobalReportPubsubMessage(BasePubsubMessage):
+    payload: ReportRequestModel 
+    version: str = "1"
+
+    @classmethod
+    def topic(cls) -> str:
+        return "global-report-events"

--- a/pharmagob/v1/models/minified/min_models.py
+++ b/pharmagob/v1/models/minified/min_models.py
@@ -112,3 +112,11 @@ class DispatchRecordDetailMin:
     prescribed_quantity: Optional[int] = None
     prescribed_at: Optional[int] = None
     context: Optional[dict] = None
+
+@dataclass
+class ReportRequestMin:
+    id: str
+    status: str
+    report_type: str
+    progress: int
+    user_id: str

--- a/pharmagob/v1/models/reports.py
+++ b/pharmagob/v1/models/reports.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass, field
+
+from typing import Any, Dict, Optional
+from ._base import UpdatableModel
+from .minified import min_models
+
+@dataclass(kw_only=True)
+class ReportRequestModel(UpdatableModel):
+    __entity_name__ = "reports-control"
+
+    status: str = "PENDING"
+    progress: int = 0
+    report_type: str = "GLOBAL_INVENTORY"
+    filters: Dict[str, Any]
+    author: min_models.UserMin
+    download_url: Optional[str] = None
+    temp_collection: Optional[str] = None
+
+    def minified(self) -> min_models.ReportRequestMin:
+        return min_models.ReportRequestMin(
+            id=self._id,
+            status=self.status,
+            report_type=self.report_type,
+            progress=self.progress,
+            user_id=self.author.id
+        )

--- a/pharmagob/v1/repository_interfaces/location_contents.py
+++ b/pharmagob/v1/repository_interfaces/location_contents.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Any
 
 from ._base import BaseRepositoryInterface
 
@@ -42,4 +42,12 @@ class LocationContentRepositoryInterface(BaseRepositoryInterface):
         location_id: Optional[str] = None,
         location_label_code: Optional[str] = None
     ) -> Tuple[int, List[dict]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def trigger_report_aggregation(
+        self, 
+        report_id: str, 
+        filters: Dict[str, Any]
+    ) -> str:
         raise NotImplementedError

--- a/pharmagob/v1/repository_interfaces/reports.py
+++ b/pharmagob/v1/repository_interfaces/reports.py
@@ -1,0 +1,17 @@
+from abc import abstractmethod
+from typing import Optional
+from pharmagob.v1.models.reports import ReportRequestModel
+from ._base import BaseRepositoryInterface
+
+class ReportRepositoryInterface(BaseRepositoryInterface):
+    @abstractmethod
+    def get_by_id(self, report_id: str) -> Optional[ReportRequestModel]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def create(self, report: ReportRequestModel) -> ReportRequestModel:
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_status(self, report_id: str, status: str, progress: int) -> bool:
+        raise NotImplementedError

--- a/pharmagob/v1/services/reports.py
+++ b/pharmagob/v1/services/reports.py
@@ -1,0 +1,10 @@
+from pharmagob.v1.models.reports import ReportRequestModel
+from pharmagob.v1.repository_interfaces.reports import ReportRepositoryInterface
+from ._base import BaseService
+
+class ReportService(BaseService[ReportRequestModel, ReportRepositoryInterface]):
+    __model__ = ReportRequestModel
+    
+    def validate_report_request(self, report: ReportRequestModel):
+        if not report.filters:
+            raise ValueError("Filters cannot be empty")


### PR DESCRIPTION
feat(domain): define core models and interfaces for global reporting

- Add ReportRequestModel to handle async report metadata
- Define ReportRepositoryInterface for report lifecycle management
- Add GlobalReportPubsubMessage to pubsub_msgs.py for cross-repo events
- Add trigger_report_aggregation to LocationContentRepositoryInterface
- Update minified models with ReportRequestMin