### PR TITLE
refactor(reports): remove redundant create method from interface

### DIFF
--- a/pharmagob/v1/models/reports.py
+++ b/pharmagob/v1/models/reports.py
@@ -1,8 +1,9 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from typing import Any, Dict, Optional
 from ._base import UpdatableModel
 from .minified import min_models
+
 
 @dataclass(kw_only=True)
 class ReportRequestModel(UpdatableModel):
@@ -22,5 +23,5 @@ class ReportRequestModel(UpdatableModel):
             status=self.status,
             report_type=self.report_type,
             progress=self.progress,
-            user_id=self.author.id
+            user_id=self.author.id,
         )

--- a/pharmagob/v1/repository_interfaces/reports.py
+++ b/pharmagob/v1/repository_interfaces/reports.py
@@ -3,13 +3,10 @@ from typing import Optional
 from pharmagob.v1.models.reports import ReportRequestModel
 from ._base import BaseRepositoryInterface
 
+
 class ReportRepositoryInterface(BaseRepositoryInterface):
     @abstractmethod
     def get_by_id(self, report_id: str) -> Optional[ReportRequestModel]:
-        raise NotImplementedError
-
-    @abstractmethod
-    def create(self, report: ReportRequestModel) -> ReportRequestModel:
         raise NotImplementedError
 
     @abstractmethod

--- a/pharmagob/v1/services/reports.py
+++ b/pharmagob/v1/services/reports.py
@@ -2,9 +2,10 @@ from pharmagob.v1.models.reports import ReportRequestModel
 from pharmagob.v1.repository_interfaces.reports import ReportRepositoryInterface
 from ._base import BaseService
 
+
 class ReportService(BaseService[ReportRequestModel, ReportRepositoryInterface]):
     __model__ = ReportRequestModel
-    
+
     def validate_report_request(self, report: ReportRequestModel):
         if not report.filters:
             raise ValueError("Filters cannot be empty")


### PR DESCRIPTION
- Removed the abstract `create` method from `ReportRepositoryInterface` as it is inherently provided by `BaseRepositoryInterface`.
- This ensures the contract remains clean, adheres to DRY principles, and perfectly matches the recent changes in the MongoDB repository implementation.