### PR TITLE
feat(location-contents): add label code exclusion to search interface

### DIFF
--- a/pharmagob/v1/repository_interfaces/location_contents.py
+++ b/pharmagob/v1/repository_interfaces/location_contents.py
@@ -20,7 +20,8 @@ class LocationContentRepositoryInterface(BaseRepositoryInterface):
         quantity_lt: Optional[int] = None,
         lot: Optional[str] = None,
         location_id: Optional[str] = None,
-        location_label_code: Optional[str] = None
+        location_label_code: Optional[str] = None,
+        location_label_code_not_in: Optional[List[str]] = None
     ) -> Tuple[int, List[dict]]:
         raise NotImplementedError
 
@@ -46,12 +47,10 @@ class LocationContentRepositoryInterface(BaseRepositoryInterface):
 
     @abstractmethod
     def trigger_report_aggregation(
-        self, 
-        report_id: str, 
-        filters: Dict[str, Any]
+        self, report_id: str, filters: Dict[str, Any]
     ) -> str:
         raise NotImplementedError
-    
+
     @abstractmethod
     def find_by_logic_triad(
         self, item_id: str, lot: str, location_id: str

--- a/pharmagob/v1/services/location_contents.py
+++ b/pharmagob/v1/services/location_contents.py
@@ -27,7 +27,8 @@ class LocationContentService(
         expiration_date_lt: Optional[int] = None,
         lot: Optional[str] = None,
         location_id: Optional[str] = None,
-        location_label_code: Optional[str] = None
+        location_label_code: Optional[str] = None,
+        location_label_code_not_in: Optional[List[str]] = None
     ) -> Tuple[int, Iterator[LocationContentModel]]:
         count, result = self.repository.search_by_item(
             search_str,
@@ -39,6 +40,7 @@ class LocationContentService(
             lot=lot,
             location_id=location_id,
             location_label_code=location_label_code,
+            location_label_code_not_in=location_label_code_not_in,
             page=page,
             limit=limit,
             sort=sort,


### PR DESCRIPTION
- Added `location_label_code_not_in` parameter to `LocationContentRepositoryInterface.search_by_item` to support negative filtering.
- Updated `LocationContentService.search_by_item` to accept the new exclusion parameter and pass it down to the repository layer.
- This change enables the API to exclude specific location labels (like 'FARB') when executing 'STANDARD' location searches.